### PR TITLE
fill miss node with ''

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -142,7 +142,17 @@ define(function(require, exports, module) {
                     importChildren(childNode, children[i].children);
                 }
             }
-
+            function fillEmptyNode(jsonMap, level) {
+                    if (jsonMap[level]){
+                        return;
+                    }
+                    jsonMap[level] = {"children":[], "data":{"text":""}};
+                    if (level < 1) {
+                        return;
+                    }
+                    fillEmptyNode(jsonMap, level - 1);
+                    addChild(jsonMap[level - 1], jsonMap[level])
+            }
             while ((line = lines[i++]) !== undefined) {
                 line = line.replace(/&nbsp;/g, '');
                 if (isEmpty(line)) continue;
@@ -155,7 +165,7 @@ define(function(require, exports, module) {
                     jsonMap[0] = children[children.length-1];
                 } else {
                     if (!jsonMap[level-1]) {
-                        throw new Error('Invalid local format');
+                        fillEmptyNode(jsonMap, level -1);
                     };
                     addChild(jsonMap[level-1], jsonNode);
                     jsonMap[level] = jsonNode;


### PR DESCRIPTION
using empty string to make jsonMap completed.
There is a scenario。 copy from xmind
`

    node1
       node2
           node3
       node3-1
           node4
`
actually, node3 is node3\n node3-1 。but when i copy the xmind node , will get above text. 
then it cannot be imported . so i fill empty string so that make sure it can be imported ,which increasing user friendly